### PR TITLE
Update README server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,38 @@
 ├── README.md                # Project documentation entry point
 └── tsconfig.json            # TypeScript configuration file
 ```
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) **18+** (any current LTS version will work)
+- [npm](https://www.npmjs.com/) (comes with Node.js)
+
+## Install Dependencies
+
+Run `npm install` from the project root to install all required packages.
+
+```bash
+npm install
+```
+
+## Running Cypress Tests
+
+- Open the Cypress UI: `npm run test`
+- Run tests headlessly: `npm run test:run`
+
+Both commands use the configuration located at `config/test.config.ts`.
+
+## Serving the HTML Resources
+
+HTML examples under `Resources/htmls` can be served locally with the built in
+`http-server` dependency:
+
+```bash
+npm run serve
+```
+
+The above command starts a static server on
+[http://localhost:8080](http://localhost:8080) or
+[http://127.0.0.1:8080](http://127.0.0.1:8080).
+Navigate to `http://localhost:8080/Resources/htmls` or
+`http://127.0.0.1:8080/Resources/htmls` to access the HTML files.


### PR DESCRIPTION
## Summary
- clarify local server addresses in the README

## Testing
- `npm run prettier -- --check README.md`
- `npm run eslint` *(fails: invalid CLI flags)*
- `npm run tsc` *(fails: missing type definitions)*
- `npm run test:run` *(fails: needs Cypress and Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_6845d1669c588328be6cf72cd3e299cc