### PR TITLE
Add dataset reset feature

### DIFF
--- a/Resources/htmls/user_management/api.js
+++ b/Resources/htmls/user_management/api.js
@@ -63,3 +63,12 @@ export function toggleStatus(id, status) {
     body: JSON.stringify({ status }),
   }).then((res) => res.json());
 }
+
+/**
+ * Resets server data back to preload state.
+ */
+export function resetData() {
+  return fetch(`${API_BASE}/reset`, {
+    method: "POST",
+  }).then((res) => res.json());
+}

--- a/Resources/htmls/user_management/index.html
+++ b/Resources/htmls/user_management/index.html
@@ -30,6 +30,7 @@
         </div>
         <div class="full-width" id="login-status" style="color: red; display: none">Invalid credentials</div>
       </form>
+      <button id="reset-btn" class="btn-secondary" style="margin-top: 0.5rem">Reset Data</button>
     </section>
 
     <!-- User Form Section -->

--- a/Resources/htmls/user_management/script.js
+++ b/Resources/htmls/user_management/script.js
@@ -5,6 +5,7 @@ import {
   updateUser,
   deleteUser,
   toggleStatus as toggleStatusApi,
+  resetData,
 } from "./api.js";
 
 // ─────────────────────────────────────────────────────────
@@ -30,6 +31,7 @@ const adminDeleteError = document.getElementById("admin-delete-error");
 const confirmModal = document.getElementById("confirm-modal");
 const confirmDeleteBtn = document.getElementById("confirm-delete");
 const cancelDeleteBtn = document.getElementById("cancel-delete");
+const resetBtn = document.getElementById("reset-btn");
 
 // ─────────────────────────────────────────────────────────
 // ✅ Admin Login / Logout
@@ -256,3 +258,15 @@ function loadUsers() {
 }
 
 loadUsers();
+
+resetBtn.addEventListener("click", async () => {
+  const ok = confirm("This will wipe all changes and restore initial users. Continue?");
+  if (!ok) return;
+  try {
+    await resetData();
+    loadUsers();
+    alert("Data reset");
+  } catch {
+    alert("Reset failed");
+  }
+});

--- a/server.js
+++ b/server.js
@@ -4,11 +4,14 @@ import bodyParser from "body-parser";
 
 const app = express();
 app.use(bodyParser.json());
-let users = [
+
+const INITIAL_USERS = [
   { id: 1, name: "Alice", role: "Admin", age: 30, email: "alice@site.com", gender: "Female", subscriptions: "Newsletter", status: "Active" },
-  { id: 2, name: "Bob",   role: "Viewer",age: 25, email: "bob@site.com",   gender: "Male",   subscriptions: "Product Updates", status: "Inactive" },
-  { id: 3, name: "Eve",   role: "Editor",age: 28, email: "eve@site.com",   gender: "Other",  subscriptions: "Newsletter, Product Updates", status: "Active" }
+  { id: 2, name: "Bob", role: "Viewer", age: 25, email: "bob@site.com", gender: "Male", subscriptions: "Product Updates", status: "Inactive" },
+  { id: 3, name: "Eve", role: "Editor", age: 28, email: "eve@site.com", gender: "Other", subscriptions: "Newsletter, Product Updates", status: "Active" },
 ];
+
+let users = [...INITIAL_USERS];
 
 // Admin login
 app.post("/api/login", (req, res) => {
@@ -59,6 +62,12 @@ app.patch("/api/users/:id/status", (req, res) => {
   if (!user) return res.status(404).json({ error: "Not found" });
   user.status = status;
   res.json(user);
+});
+
+// Reset in-memory data back to initial state
+app.post("/api/reset", (req, res) => {
+  users = [...INITIAL_USERS];
+  return res.json({ success: true, users });
 });
 
 app.use(express.static("Resources/htmls/user_management"));


### PR DESCRIPTION
## Summary
- keep initial demo data on the server
- expose `/api/reset` endpoint
- provide `resetData` helper
- add Reset Data button to the UI and hook it up

## Testing
- `npm run prettier:local:linux`
- `npm run eslint:local` *(fails: Unable to resolve module paths)*
- `npm run tsc:local` *(fails: Cannot find module 'Plugins/index')*

------
https://chatgpt.com/codex/tasks/task_e_68531f03f48c8328bd0c79d36cbdbca4