### PR TITLE
feat(user_management_v2): add error message container for admin deletion

### DIFF
--- a/Resources/htmls/user_management_v2/FE/index.html
+++ b/Resources/htmls/user_management_v2/FE/index.html
@@ -90,6 +90,7 @@
             <input class="search-input" id="search-input" placeholder="Search by Name, Email or Role" type="text" />
             <button class="btn-primary" id="open-user-modal">+ Add New User</button>
           </div>
+          <div id="admin-delete-error" style="color: red; display: none; margin-bottom: 0.5rem"></div>
 
           <table id="user-table">
             <thead>


### PR DESCRIPTION
- Introduce `#admin-delete-error` element for displaying error messages related to admin deletion.
- Ensure the container is hidden by default and styled for visibility when needed.