### PR TITLE
feat(user_management): add generators for seed data and improve reusa…

### DIFF
--- a/Cypress/Fixtures/Builders/Lecture/UserManagementBuilders.ts
+++ b/Cypress/Fixtures/Builders/Lecture/UserManagementBuilders.ts
@@ -1,4 +1,5 @@
 ﻿import { UserManagementEndpoints } from "EndPoints/Lecture/UserManagementEndpoints";
+import { UserManagementGenerators } from "Generators/Lecture/UserManagementGenerators";
 import { UserManagementModels } from "Models/Lecture/UserManagementModels";
 
 export class UserManagementBuilders {
@@ -69,11 +70,23 @@ export class UserManagementBuilders {
     });
   }
 
-  static seedData(users: UserManagementModels.UserInput[]) {
+  static seedData() {
     return cy.request({
       method: "POST",
       url: UserManagementEndpoints.seed(),
-      body: { users, overwrite: false },
+      body: { user: UserManagementGenerators.userDataPositive(50), overwrite: false },
     });
   }
+
+  static AdminLogin = (email: string, password: string, failOnStatusCode: boolean = true) => {
+    return cy.request({
+      method: "POST",
+      url: UserManagementEndpoints.adminLogin,
+      body: {
+        email,
+        password,
+      },
+      failOnStatusCode: failOnStatusCode,
+    });
+  };
 }

--- a/Cypress/Fixtures/Generators/Lecture/UserManagementGenerators.ts
+++ b/Cypress/Fixtures/Generators/Lecture/UserManagementGenerators.ts
@@ -1,0 +1,37 @@
+﻿import Chance from "chance";
+import { UserManagementModels } from "Models/Lecture/UserManagementModels";
+
+const chance = new Chance();
+
+export class UserManagementGenerators {
+  static defaultUser: UserManagementModels.UserInput = {
+    name: "Narek",
+    role: UserManagementModels.Role.Admin,
+    age: 30,
+    email: "narek@site",
+    gender: UserManagementModels.Gender.Male,
+    subscriptions: [UserManagementModels.Subscription.Newsletter, UserManagementModels.Subscription.ProductUpdates],
+  };
+  static userDataPositive(count: number = 1): UserManagementModels.UserInput[] {
+    const users = [];
+    for (let i = 0; i < count; i++) {
+      users.push({
+        name: chance.name().split(" ")[0], // Narek Hovhannisyan => [Narek, Hovhannisyan]
+        role: chance.pickone(Object.values(UserManagementModels.Role)),
+        age: chance.integer({ min: 1, max: 100 }),
+        email: chance.email({
+          domain: "site.com",
+        }),
+        gender: chance.pickone(Object.values(UserManagementModels.Gender)),
+        subscriptions: chance.pickset(
+          Object.values(UserManagementModels.Subscription),
+          chance.integer({
+            min: 0,
+            max: 2,
+          })
+        ),
+      });
+    }
+    return users;
+  }
+}

--- a/Cypress/Fixtures/Models/Lecture/UserManagementModels.ts
+++ b/Cypress/Fixtures/Models/Lecture/UserManagementModels.ts
@@ -17,7 +17,6 @@
   export enum Subscription {
     Newsletter = "Newsletter",
     ProductUpdates = "Product Updates",
-    Promotions = "Promotions",
   }
 
   /** Enumerates user status */

--- a/Cypress/Tests/API/Lecture/UserManagementAPI.ts
+++ b/Cypress/Tests/API/Lecture/UserManagementAPI.ts
@@ -1,4 +1,5 @@
 ﻿import { UserManagementBuilders } from "Builders/Lecture/UserManagementBuilders";
+import { UserManagementGenerators } from "Generators/Lecture/UserManagementGenerators";
 import { UserManagementModels } from "Models/Lecture/UserManagementModels";
 
 /**
@@ -62,18 +63,15 @@ describe("User Management API – Cypress Sandbox", () => {
    * @test Creates a new user via API
    */
   it("POST /api/users creates a new user", () => {
-    const newUser: UserManagementModels.UserUpdate = {
-      name: "ApiUser",
-      role: UserManagementModels.Role.Viewer,
-      age: 24,
-      email: "apiuser@example.com",
-      gender: UserManagementModels.Gender.Other,
-      subscriptions: [UserManagementModels.Subscription.Newsletter],
-    };
-
-    UserManagementBuilders.createUser(newUser).then((resp) => {
+    const user = UserManagementGenerators.defaultUser;
+    UserManagementBuilders.createUser(user).then((resp) => {
       expect(resp.status).to.eq(200);
-      expect(resp.body).to.include({ name: newUser.name, email: newUser.email });
+      expect(resp.body.name).eq(user.name);
+      expect(resp.body.email).eq(user.email);
+      expect(resp.body.subscriptions).to.be.an("array");
+      expect(resp.body.subscriptions.length).to.eq(2);
+      expect(resp.body.status).eq("Active");
+
       createdUserId = resp.body.id;
     });
   });

--- a/Cypress/Tests/E2E/Lecture/UserManagementE2EV2.ts
+++ b/Cypress/Tests/E2E/Lecture/UserManagementE2EV2.ts
@@ -7,31 +7,18 @@ import { UserManagementPageV2 } from "Pages/Lecture/UserManagementPageV2";
 const chance = new Chance();
 describe("User Management – Cypress Sandbox", () => {
   const baseUrl = "/";
-  const users: UserManagementModels.UserInput[] = [];
+  let users: UserManagementModels.UserInput[] = [];
 
-  for (let i = 0; i < 50; i++) {
-    users.push({
-      name: chance.name().split(" ")[0],
-      role: chance.pickone(Object.values(UserManagementModels.Role)),
-      age: chance.integer({ min: 1, max: 100 }),
-      email: chance.email(),
-      gender: chance.pickone(Object.values(UserManagementModels.Gender)),
-      subscriptions: chance.pickset(
-        Object.values(UserManagementModels.Subscription),
-        chance.integer({
-          min: 0,
-          max: 3,
-        })
-      ),
-    });
-  }
 
   before(() => {
     UserManagementBuilders.resetData();
-    UserManagementBuilders.seedData(users);
+    UserManagementBuilders.seedData();
   });
 
   beforeEach(() => {
+    UserManagementBuilders.getUsers().then((res) => {
+      users = res.body;
+    });
     cy.intercept("GET", UserManagementEndpoints.users()).as("getUsers");
     cy.visit(baseUrl);
     cy.wait("@getUsers");


### PR DESCRIPTION
…ble logic

- Introduce `UserManagementGenerators` for generating default and random user data.
- Update `UserManagementBuilders` with `AdminLogin` method and dynamic seed data generation.
- Simplify test setup by leveraging `UserManagementGenerators` for test scenarios.
- Remove unused `Promotions` subscription type from models.
- Refactor tests to use reusable logic for enhanced maintainability.